### PR TITLE
[1.x] Add `onlyFields` method to `Resource` and `Form` fakers

### DIFF
--- a/src/Concerns/CanSpecifyFields.php
+++ b/src/Concerns/CanSpecifyFields.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FilamentFaker\Concerns;
+
+/**
+ * @internal
+ */
+trait CanSpecifyFields
+{
+    /** @var string[] */
+    protected array $onlyFields = [];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onlyFields(string ...$fields): static
+    {
+        return tap($this, function () use ($fields) {
+            $this->onlyFields = $fields;
+        });
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getOnlyFields(): array
+    {
+        return $this->onlyFields;
+    }
+}

--- a/src/Concerns/TransformsFakes.php
+++ b/src/Concerns/TransformsFakes.php
@@ -78,6 +78,10 @@ trait TransformsFakes
         if (filled($this->mutateCallback)) {
             $faker->mutateFake($this->mutateCallback);
         }
+
+        if (method_exists($this, 'getOnlyFields') && $faker instanceof FakesForms) {
+            $faker->onlyFields(...$this->getOnlyFields());
+        }
     }
 
     abstract protected function usesFactory(): bool;

--- a/src/Contracts/Fakers/FakesForms.php
+++ b/src/Contracts/Fakers/FakesForms.php
@@ -41,4 +41,11 @@ interface FakesForms
      * output of mock data.
      */
     public function mutateFake(Closure $callback = null): static;
+
+    /**
+     * Specify which fields to generate data for.
+     *
+     * @param  string[]  ...$fields
+     */
+    public function onlyFields(string ...$fields): static;
 }

--- a/src/Fakers/ResourceFaker.php
+++ b/src/Fakers/ResourceFaker.php
@@ -8,11 +8,14 @@ use Closure;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Resources\Resource as FilamentResource;
+use FilamentFaker\Concerns\CanSpecifyFields;
 use FilamentFaker\Contracts\Fakers\FakesResources;
 use FilamentFaker\Support\Livewire;
 
 class ResourceFaker extends FilamentFaker implements FakesResources
 {
+    use CanSpecifyFields;
+
     /**
      * @var class-string<FilamentResource>
      */

--- a/tests/Feature/Fakers/Forms/FormOnlyFieldsTest.php
+++ b/tests/Feature/Fakers/Forms/FormOnlyFieldsTest.php
@@ -10,5 +10,10 @@ it('returns only fields in only fields array', function () {
     ]);
 
     $fake = $form->faker()->onlyFields('foo', 'bar')->fake();
-    expect(array_keys($fake))->toEqual(['foo', 'bar']);
+    expect(array_keys($fake))
+        ->toEqual(['foo', 'bar'])
+        ->and($fake['foo'])
+        ->toBeString()
+        ->and($fake['bar'])
+        ->toBeString();
 });

--- a/tests/Feature/Fakers/Forms/FormOnlyFieldsTest.php
+++ b/tests/Feature/Fakers/Forms/FormOnlyFieldsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Filament\Forms\Components\TextInput;
+
+it('returns only fields in only fields array', function () {
+    $form = mockForm()->schema([
+        TextInput::make('foo'),
+        TextInput::make('bar'),
+        TextInput::make('baz'),
+    ]);
+
+    $fake = $form->faker()->onlyFields('foo', 'bar')->fake();
+    expect(array_keys($fake))->toEqual(['foo', 'bar']);
+});

--- a/tests/Feature/Fakers/Resources/ResourceFakeOnlyFieldsTest.php
+++ b/tests/Feature/Fakers/Resources/ResourceFakeOnlyFieldsTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use FilamentFaker\Tests\TestSupport\Resources\PostResource;
+
+it('returns only fields in only fields array', function () {
+    $resourceFaker = PostResource::faker()->faker()->onlyFields('safe_email', 'title');
+
+    expect(array_keys($resourceFaker->fake()))->toEqual(['safe_email', 'title']);
+});

--- a/tests/Feature/Fakers/Resources/ResourceFakeOnlyFieldsTest.php
+++ b/tests/Feature/Fakers/Resources/ResourceFakeOnlyFieldsTest.php
@@ -3,7 +3,7 @@
 use FilamentFaker\Tests\TestSupport\Resources\PostResource;
 
 it('returns only fields in only fields array', function () {
-    $resourceFaker = PostResource::faker()->faker()->onlyFields('safe_email', 'title');
+    $resourceFaker = PostResource::faker()->onlyFields('safe_email', 'title');
 
     expect(array_keys($resourceFaker->fake()))->toEqual(['safe_email', 'title']);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,8 +1,10 @@
 <?php
 
+use Filament\Forms\Form;
 use FilamentFaker\Contracts\Decorators\ComponentDecorator;
 use FilamentFaker\Decorators\Component;
 use FilamentFaker\Tests\TestCase;
+use FilamentFaker\Tests\TestSupport\Resources\ProductResource;
 use Mockery\MockInterface;
 
 uses(TestCase::class)->in(__DIR__);
@@ -15,4 +17,9 @@ function mockComponentDecorator(MockInterface $mock = null)
     }
 
     app()->instance(ComponentDecorator::class, $mock);
+}
+
+function mockForm(): Form
+{
+    return ProductResource::faker()->getForm()->schema();
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,5 +21,5 @@ function mockComponentDecorator(MockInterface $mock = null)
 
 function mockForm(): Form
 {
-    return ProductResource::faker()->getForm()->schema();
+    return ProductResource::faker()->getForm();
 }


### PR DESCRIPTION
This feature adds `onlyFields` allowing the user to select which fields they want from the generator.

Method can be chained onto the FilamentFaker API for Forms and Resources.
```php
$data = PostResource::faker()->onlyFields('title', 'content', 'image_url')->fake();
```